### PR TITLE
8 to be tested first remove ai reasoning tokens from previous responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "perplexity-ext",
   "displayName": "perplexity-ext",
   "description": "AI Integration for Perplexity.ai with VSCode",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "engines": {
     "vscode": "^1.96.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,10 +25,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	const disposableChatWindow = vscode.commands.registerCommand('perplexity-ext.openChatWindow', async () => {
 
-		let messageContext: PerplexityMessage[] = [{
-			role: "system", 
-			content: "Make sure you are correct!"
-		}];
+		let messageContext: PerplexityMessage[] = [];
 
 		let model = "sonar"; 
 
@@ -92,6 +89,14 @@ export function activate(context: vscode.ExtensionContext) {
 						};
 						messageContext.push(previousUserPrompt); 
 						messageContext.push(previousAiResponse); 
+
+						// Add limit of 16 total messages to not use up too many tokens 
+
+						if(messageContext.length > 16) {
+							messageContext.shift(); 
+							messageContext.shift(); 
+						}
+
 						console.log(messageContext);
 				}
 			}

--- a/src/perplexity.ts
+++ b/src/perplexity.ts
@@ -26,6 +26,10 @@ export default async function sendMessageToPerplexity(
 	const requestBody: PerplexityRequest = {
 		model: model,
 		messages: [
+			{
+				role: "system", 
+				content: "Make sure you are correct!"
+			},
 			...context, 
 			{
 				role: "user",

--- a/src/webviewContent.ts
+++ b/src/webviewContent.ts
@@ -231,6 +231,13 @@ export default function getWebviewContent(webview: vscode.Webview): string {
                 currentResponseText.innerText += message.content;
             } else if (message.command === "complete") {
                 // Process final Markdown rendering
+
+                // Remove all returned reasononing tokens from the response as they take a lot tokens
+                const indexOfStartReasoningTokens = currentResponseText.innerText.indexOf("<think>");
+                const indexOfEndReasoningTokens = currentResponseText.innerText.indexOf("</think>");
+
+                currentResponseText.innerText = currentResponseText.innerText.slice(0, indexOfStartReasoningTokens) + currentResponseText.innerText.slice(indexOfEndReasoningTokens + 8, currentResponseText.innerText.length); 
+
                 responseTextMessageForContext = currentResponseText.innerText.trim();
                 currentResponseText.innerHTML =   md.render(currentResponseText.innerText)
                 responseText.insertAdjacentHTML('beforeend', currentResponseText.innerHTML);


### PR DESCRIPTION
- After the message is complete, the <think> </think> section is removed from currentResponseText on every "complete" signal sent *to* the embedded webview
- Added message history limit of 16 (8 user messages and 8 assistant replies) 
